### PR TITLE
Potential fix for code scanning alert no. 29: DOM text reinterpreted as HTML

### DIFF
--- a/Mofang/templates/firewall.html
+++ b/Mofang/templates/firewall.html
@@ -761,7 +761,8 @@
             var rows = currentRules.map(function (rule, idx) {
                 var dir = (rule.direction || 'in').toLowerCase();
                 var proto = (rule.protocol || 'tcp').toLowerCase();
-                var action = (rule.action || 'ACCEPT').toUpperCase();
+                var rawAction = (rule.action || 'ACCEPT').toUpperCase();
+                var action = rawAction === 'ACCEPT' ? 'ACCEPT' : 'DROP';
                 var network = (rule.network || 'ipv4').toLowerCase();
                 var port = escapeHtml(portDisplay(rule.port));
                 var srcIp = escapeHtml(sourceIpDisplay(rule.source_ip));


### PR DESCRIPTION
Potential fix for [https://github.com/MengMengCode/CLICD/security/code-scanning/29](https://github.com/MengMengCode/CLICD/security/code-scanning/29)

The safest fix is to ensure untrusted form values cannot reach HTML attribute concatenation unsafely. Here, the minimal, non-breaking fix is to **strictly whitelist `action` values** before building `actionClass`, so only expected tokens (`ACCEPT`, `DROP`) are allowed.

Best single fix in this snippet:
- In `renderRules` (around lines 764/772/780), normalize and validate action:
  - Read raw action as uppercase.
  - Map to safe value: `var action = rawAction === 'ACCEPT' ? 'ACCEPT' : 'DROP';`
  - Build `actionClass` from that safe enum only.
This preserves current behavior (non-`ACCEPT` already renders as “拒绝”) while removing injection risk from class concatenation.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
