### PR TITLE
fix(kvm): Windows 首启脚本盘符扫描的批处理语法错误，导致 RDP/入站端口全被丢弃

### DIFF
--- a/backend/internal/kvm/kvm.go
+++ b/backend/internal/kvm/kvm.go
@@ -1906,7 +1906,7 @@ func windowsAutounattendXML(hostname, adminPassword string, windows11 bool) stri
 		hostname = "clicd-win"
 	}
 	hostname = sanitizeWindowsComputerName(hostname)
-	setupCommand := `cmd.exe /c if exist C:\CLICD\FirstLogon.ps1 (powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\CLICD\FirstLogon.ps1) else (for %%d in (D E F G H I J K L M N O P Q R S T U V W X Y Z) do @if exist %%d:\FirstLogon.ps1 powershell.exe -NoProfile -ExecutionPolicy Bypass -File %%d:\FirstLogon.ps1)`
+	setupCommand := `cmd.exe /c if exist C:\CLICD\FirstLogon.ps1 (powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\CLICD\FirstLogon.ps1) else (for %d in (D E F G H I J K L M N O P Q R S T U V W X Y Z) do @if exist %d:\FirstLogon.ps1 powershell.exe -NoProfile -ExecutionPolicy Bypass -File %d:\FirstLogon.ps1)`
 	compatibilityCommands := ""
 	if windows11 {
 		compatibilityCommands = `


### PR DESCRIPTION
## 问题

给 KVM Windows 虚拟机配置了 NAT 端口映射（外部 20000→ 内部 3389 的 RDP），宿主机上的 iptables DNAT 规则是正确的，guest 也拿到了 DHCP 地址，但从宿主机 `nc` 连 guest 的 3389 / 其它端口全部**卡住无响应**（不是 refused）。即映射看似存在、实际连不通。

## 根因

Windows 安装后的初始化（开启 RDP、放行防火墙、把网络设为 Private、安装 qemu-ga）全部依赖 unattend 的 `FirstLogon.ps1`，而它靠 `FirstLogonCommands` 里的这段命令来定位执行：

```
cmd.exe /c if exist C:\CLICD\FirstLogon.ps1 (...) else (for %%d in (D E F ... Z) do @if exist %%d:\FirstLogon.ps1 ...)
```

- 该命令通过 `cmd.exe /c` 以**命令行方式**执行，此时 `for` 的循环变量必须是 `%d`，而不是批处理文件里的 `%%d`。`%%d` 会触发 `%%d was unexpected at this time`，**else 分支整段失败**。
- 而主分支要找的 `C:\CLICD\FirstLogon.ps1` 也不存在——`$OEM$` 目录在单独的 unattend ISO 上不会被安装程序处理，脚本不会被落地到系统盘。

两条投递路径都断了，`FirstLogon.ps1` 从未执行 → RDP 没开、防火墙没放行、网络 profile 停留在 Public 默认丢弃所有入站。宿主机 DNAT 没问题，是 guest 内部把包丢了，所以映射看起来"没生效"。

## 修复

把 `setupCommand` 里的 `%%d` 改为 `%d`（3 处）。这样 `FirstLogonCommands` 就能正确遍历盘符、找到并执行 unattend ISO 根目录下的 `FirstLogon.ps1`（该文件本就写在 ISO 根，见 createWindowsUnattendISO）。

单行改动，仅影响 Windows 新建/重装的首启初始化；已装好的实例需在 guest 内手动执行一次开 RDP 的命令或重装才能生效。

注：`setupCommand` 是作为数据参数传给 `fmt.Sprintf` 的（非格式串），`%d` 不会被格式化解释，不影响编译。